### PR TITLE
Fixing meal plan display bug

### DIFF
--- a/src/app/components/mealplan/mealplan.component.ts
+++ b/src/app/components/mealplan/mealplan.component.ts
@@ -159,7 +159,12 @@ export class MealplanComponent implements OnInit {
    */
 
   private selectMealPlan(meal_plan) {
-    this.selected_mp = meal_plan;
+
+    // get any new data for this meal plan
+    this.mealPlanService.getUserMealPlanById(meal_plan.id).subscribe( mp => {
+      this.selected_mp = mp;
+    });
+
   }
 
   /*

--- a/src/app/services/meal-plan.service.ts
+++ b/src/app/services/meal-plan.service.ts
@@ -35,14 +35,13 @@ export class MealPlanService implements OnInit {
     }).catch(this.handleError);
   }
 
-  // GET /users/:user_id/meal_plans/:id
+  // GET /meal_plans/:id
   public getUserMealPlanById(mealPlanID: number) {
-    return this.authTokenService.get('/users/' +
-                                      this.userID +
-                                      '/meal_plans/' +
+
+    return this.authTokenService.get('meal_plans/' +
                                       mealPlanID)
     .map( res => {
-      return this.jsonConvert.deserialize(res.json(), MealPlan);;
+      return this.jsonConvert.deserialize(res.json(), MealPlan);
     }).catch(this.handleError);
   }
 


### PR DESCRIPTION
Fixing a small bug: if a new meal plan was created, then modified, then selected again, the selected meal plan did not update based on the user's input. Added a specific GET request to update the target meal plan's data upon selection.